### PR TITLE
Changed minor typos excersie 13

### DIFF
--- a/lesson-4-training-validation-experiment-tracking/exercises/exercise_13/README.md
+++ b/lesson-4-training-validation-experiment-tracking/exercises/exercise_13/README.md
@@ -6,7 +6,7 @@ Then, you will mark that model as "production ready".
 In order to complete this exercise, go to the ``run.py`` file and complete the code when
 requested by comments such as ``## YOUR CODE HERE``. Further instructions are provided there.
 
-Then, run the component using the model exported in ``exercise_14`` 
+Then, run the component using the model exported in ``exercise_12`` 
 (``exercise_12/model_export:latest``) and the test data (``exercise_6/data_test.csv:latest``).
 
 Verify that the AUC and the confusion matrix look good, then go to the Artifact section in W&B

--- a/lesson-4-training-validation-experiment-tracking/exercises/exercise_13/starter/run.py
+++ b/lesson-4-training-validation-experiment-tracking/exercises/exercise_13/starter/run.py
@@ -16,7 +16,8 @@ def go(args):
     run = wandb.init(project="exercise_13", job_type="test")
 
     logger.info("Downloading and reading test artifact")
-    test_data_path = ## Get the args.test_data artifact from W&B locally
+    ## Get the args.test_data artifact from W&B locally
+    test_data_path = ## YOUR CODE HERE
     df = pd.read_csv(test_data_path, low_memory=False)
 
     # Extract the target from the features


### PR DESCRIPTION
In the Readme you say to use the model exported in exercise_14 however this is exercise_13 so I assume you mean to use exercise_12 actually and that is what the model_export is using.

To be clearer where the students need to add code I added the ## YOUR CODE HERE because it was not consistent with the following examples.